### PR TITLE
feat: add ability to save and load frameworks

### DIFF
--- a/risk_of_bias/cli.py
+++ b/risk_of_bias/cli.py
@@ -40,6 +40,9 @@ def main(
         verbose=verbose,
     )
 
+    output_path = manuscript_path.with_suffix(manuscript_path.suffix + ".json")
+    completed_framework.save(output_path)
+
     return completed_framework
 
 

--- a/risk_of_bias/types/_framework_types.py
+++ b/risk_of_bias/types/_framework_types.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from pydantic import BaseModel
 
 from risk_of_bias.types._domain_types import Domain
@@ -111,3 +113,29 @@ class Framework(BaseModel):
                 lines.append("")
 
         return "\n".join(lines)
+
+    def save(self, path: Path) -> None:
+        """Save the framework as formatted JSON to ``path``.
+
+        Parameters
+        ----------
+        path : Path
+            Location to write the JSON representation.
+        """
+        path.write_text(self.model_dump_json(indent=2))
+
+    @classmethod
+    def load(cls, path: Path) -> "Framework":
+        """Load a framework from a JSON file at ``path``.
+
+        Parameters
+        ----------
+        path : Path
+            The file to read from.
+
+        Returns
+        -------
+        Framework
+            An instance populated with the data from the file.
+        """
+        return cls.model_validate_json(path.read_text())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,10 @@ def test_cli_runs_with_defaults(tmp_path, monkeypatch):
         called["framework"] = framework
         called["guidance"] = guidance_document
         called["verbose"] = verbose
-        return "result"
+        # return a minimal Framework instance so cli can call .save()
+        from risk_of_bias.types._framework_types import Framework
+
+        return Framework(name="dummy")
 
     monkeypatch.setattr(cli, "run_framework", fake_run_framework)
 
@@ -33,3 +36,5 @@ def test_cli_runs_with_defaults(tmp_path, monkeypatch):
     assert called["manuscript"] == pdf
     assert called["model"] == settings.fast_ai_model
     assert called["guidance"] is None
+    # the framework should be saved next to the manuscript
+    assert (pdf.with_suffix(pdf.suffix + ".json")).exists()

--- a/tests/test_framework_io.py
+++ b/tests/test_framework_io.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from risk_of_bias.frameworks.rob2 import get_rob2_framework
+from risk_of_bias.types._framework_types import Framework
+
+
+def test_framework_save_and_load(tmp_path: Path) -> None:
+    framework = get_rob2_framework()
+    save_path = tmp_path / "rob2.json"
+    framework.save(save_path)
+
+    loaded = Framework.load(save_path)
+    assert isinstance(loaded, Framework)
+    assert loaded.name == framework.name
+    assert len(loaded.domains) == len(framework.domains)


### PR DESCRIPTION
## Summary
- allow Framework objects to be saved and loaded as JSON
- CLI writes the completed framework next to the provided PDF
- test saving and loading of RoB2 framework
- update CLI test for new behaviour

## Testing
- `make test`
- `make lint` *(fails: `mypy .` interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684831fd2730832aadaf7420e8a8d2d1