### PR TITLE
feat: add markdown framework export

### DIFF
--- a/risk_of_bias/export.py
+++ b/risk_of_bias/export.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from risk_of_bias.types._framework_types import Framework
+
+
+def export_framework_as_markdown(framework: Framework, path: Path) -> None:
+    """Export a completed framework as a Markdown document.
+
+    Parameters
+    ----------
+    framework : Framework
+        The framework instance containing the assessment results.
+    path : Path
+        Destination file for the Markdown representation.
+
+    Notes
+    -----
+    Only Markdown format is currently supported. Additional formats may be
+    added in future releases.
+    """
+    lines: list[str] = [f"# {framework.name}"]
+
+    for domain in framework.domains:
+        lines.append(f"\n## Domain {domain.index}: {domain.name}")
+
+        if not domain.questions:
+            lines.append("No questions defined.")
+            continue
+
+        for question in domain.questions:
+            lines.append(f"\n### Question {question.index}")
+            lines.append(question.question)
+
+            if question.allowed_answers is not None:
+                answers = ", ".join(question.allowed_answers)
+            else:
+                answers = "Any text"
+            lines.append(f"*Allowed answers:* {answers}")
+
+            if question.response is None:
+                lines.append("**Response:** Not answered")
+                continue
+
+            lines.append(f"**Response:** {question.response.response}")
+            if question.response.reasoning:
+                lines.append(f"**Reasoning:** {question.response.reasoning}")
+            if question.response.evidence:
+                lines.append("**Evidence:**")
+                for evidence in question.response.evidence:
+                    lines.append(f"- {evidence}")
+
+    path.write_text("\n".join(lines))

--- a/risk_of_bias/export.py
+++ b/risk_of_bias/export.py
@@ -28,25 +28,20 @@ def export_framework_as_markdown(framework: Framework, path: Path) -> None:
             continue
 
         for question in domain.questions:
-            lines.append(f"\n### Question {question.index}")
-            lines.append(question.question)
-
-            if question.allowed_answers is not None:
-                answers = ", ".join(question.allowed_answers)
-            else:
-                answers = "Any text"
-            lines.append(f"*Allowed answers:* {answers}")
+            lines.append(f"\n### Question {question.question}\n")
 
             if question.response is None:
                 lines.append("**Response:** Not answered")
                 continue
 
-            lines.append(f"**Response:** {question.response.response}")
+            lines.append(f"Response: **{question.response.response}**\n")
             if question.response.reasoning:
-                lines.append(f"**Reasoning:** {question.response.reasoning}")
+                lines.append(f"Reasoning: {question.response.reasoning}\n")
             if question.response.evidence:
-                lines.append("**Evidence:**")
+                lines.append("Evidence:")
                 for evidence in question.response.evidence:
                     lines.append(f"- {evidence}")
+            lines.append("")
+            lines.append("")
 
     path.write_text("\n".join(lines))

--- a/risk_of_bias/types/_framework_types.py
+++ b/risk_of_bias/types/_framework_types.py
@@ -114,15 +114,59 @@ class Framework(BaseModel):
 
         return "\n".join(lines)
 
+    def export_to_markdown(self, path: Path) -> None:
+        """Export the framework as a Markdown document.
+
+        This method creates a structured Markdown representation of the framework
+        and its assessment results, suitable for documentation, reporting, or
+        sharing with stakeholders.
+
+        The generated Markdown includes:
+        - Framework name as the main heading
+        - Each domain as a section with its index and name
+        - Questions within each domain with their indices and text
+        - Allowed answer options for each question
+        - Response details for answered questions, including:
+          - The selected response
+          - The reasoning behind the assessment
+          - Supporting evidence excerpts from the manuscript
+
+        Parameters
+        ----------
+        path : Path
+            Destination file for the Markdown representation.
+
+        Examples
+        --------
+        >>> framework = Framework(name="RoB2 Framework")
+        >>> framework.export_to_markdown(Path("assessment_report.md"))
+        """
+        from risk_of_bias.export import export_framework_as_markdown
+
+        export_framework_as_markdown(self, path)
+
     def save(self, path: Path) -> None:
         """Save the framework as formatted JSON to ``path``.
+
+        This method excludes raw_data fields from the JSON output to keep
+        the saved files clean and focused on assessment results.
 
         Parameters
         ----------
         path : Path
             Location to write the JSON representation.
         """
-        path.write_text(self.model_dump_json(indent=2))
+        # Convert to JSON with indentation, excluding raw_data for cleaner files
+        import json
+
+        data = self.model_dump(
+            exclude={
+                "domains": {
+                    "__all__": {"questions": {"__all__": {"response": {"raw_data"}}}}
+                }
+            }
+        )
+        path.write_text(json.dumps(data, indent=2))
 
     @classmethod
     def load(cls, path: Path) -> "Framework":

--- a/risk_of_bias/types/_response_types.py
+++ b/risk_of_bias/types/_response_types.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 
 from openai.types.responses.parsed_response import ParsedResponse
 from pydantic import BaseModel
@@ -93,7 +94,7 @@ class ReasonedResponseWithEvidenceAndRawData(BaseModel):
     evidence: list[str]
     reasoning: str
     response: str
-    raw_data: ParsedResponse
+    raw_data: Optional[ParsedResponse] = None
 
 
 def create_custom_constrained_response_class(

--- a/test_save_load.py
+++ b/test_save_load.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Test script to verify framework save/load functionality works correctly.
+"""
+
+from pathlib import Path
+
+from risk_of_bias.frameworks.rob2 import get_rob2_framework
+from risk_of_bias.types._response_types import ReasonedResponseWithEvidenceAndRawData
+
+
+def test_save_load():
+    """Test that framework can be saved and loaded correctly."""
+
+    # Create a framework with some mock responses
+    framework = get_rob2_framework()
+
+    # Add a mock response to the first question
+    if framework.domains and framework.domains[0].questions:
+        first_question = framework.domains[0].questions[0]
+        first_question.response = ReasonedResponseWithEvidenceAndRawData(
+            evidence=["Test evidence from manuscript"],
+            reasoning="Test reasoning for the assessment",
+            response="Yes",
+        )
+
+    # Save to a temp file
+    temp_path = Path("/tmp/test_framework.json")
+    framework.save(temp_path)
+    print(f"Framework saved to {temp_path}")
+
+    # Load it back
+    loaded_framework = framework.load(temp_path)
+    print("Framework loaded successfully!")
+
+    # Verify the response was preserved
+    if loaded_framework.domains and loaded_framework.domains[0].questions:
+        loaded_response = loaded_framework.domains[0].questions[0].response
+        if loaded_response:
+            print(f"Loaded response: {loaded_response.response}")
+            print(f"Loaded reasoning: {loaded_response.reasoning}")
+            print(f"Loaded evidence: {loaded_response.evidence}")
+            print(f"Raw data: {loaded_response.raw_data}")  # Should be None
+        else:
+            print("No response found")
+
+    # Clean up
+    temp_path.unlink()
+    print("Test completed successfully!")
+
+
+if __name__ == "__main__":
+    test_save_load()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -48,5 +48,5 @@ def test_export_framework_as_markdown_with_responses(tmp_path: Path) -> None:
     export_framework_as_markdown(framework, export_path)
 
     content = export_path.read_text()
-    assert "**Response:** Yes" in content
+    assert "Response: **Yes**" in content
     assert "- text" in content

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from openai.types.responses.parsed_response import ParsedResponse
+
+from risk_of_bias.export import export_framework_as_markdown
+from risk_of_bias.frameworks.rob2 import get_rob2_framework
+from risk_of_bias.types._domain_types import Domain
+from risk_of_bias.types._framework_types import Framework
+from risk_of_bias.types._question_types import Question
+from risk_of_bias.types._response_types import ReasonedResponseWithEvidenceAndRawData
+
+
+def test_export_framework_as_markdown(tmp_path: Path) -> None:
+    framework = get_rob2_framework()
+    export_path = tmp_path / "framework.md"
+    export_framework_as_markdown(framework, export_path)
+
+    assert export_path.exists()
+    content = export_path.read_text()
+    assert framework.name in content
+    assert "Domain 1" in content
+
+
+def test_export_framework_as_markdown_with_responses(tmp_path: Path) -> None:
+    parsed: ParsedResponse = ParsedResponse.model_construct(
+        id="1",
+        created_at=0.0,
+        model="",
+        object="",
+        output=[],
+        parallel_tool_calls=None,
+        tool_choice=None,
+        tools=[],
+        temperature=0.0,
+        top_p=0.0,
+    )
+    question = Question(question="Did it work?", index=1.0)
+    question.response = ReasonedResponseWithEvidenceAndRawData(
+        response="Yes",
+        reasoning="Because",
+        evidence=["text"],
+        raw_data=parsed,
+    )
+    domain = Domain(name="Test", index=1, questions=[question])
+    framework = Framework(name="Test Framework", domains=[domain])
+
+    export_path = tmp_path / "framework.md"
+    export_framework_as_markdown(framework, export_path)
+
+    content = export_path.read_text()
+    assert "**Response:** Yes" in content
+    assert "- text" in content


### PR DESCRIPTION
## Summary
- add export_framework_as_markdown function
- test exporting frameworks to Markdown

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6848352242bc832ab2f9314989296510