### PR TITLE
feat: add simple FastAPI web interface

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e .[dev]
+          pip install -e .[all]
 
       - name: Run tests
         run: make lint-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e .[dev]
+          pip install -e .[all]
 
       - name: Run tests
         run: pytest tests

--- a/docs/web.md
+++ b/docs/web.md
@@ -1,0 +1,18 @@
+# Web Interface
+
+A simple web front end is provided using [FastAPI](https://fastapi.tiangolo.com/).
+It lets you upload a PDF and view the standard RoB2 HTML report directly in your
+browser.
+
+## Running the server
+
+Install the optional dependencies and start the server with `uvicorn`:
+
+```console
+pip install "risk_of_bias[web]"
+uvicorn risk_of_bias.web:app --reload
+```
+
+Open `http://127.0.0.1:8000` and upload your manuscript. After processing you
+will see the report along with links to download the JSON and Markdown
+representations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Frameworks: frameworks.md
     - Command Line Interface: cli.md
     - API: api.md
+    - Web: web.md
     - Contributing: contributing.md
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ web = [
     "uvicorn>=0.29.0",
     "python-multipart>=0.0.9",
 ]
+all = [
+    "risk-of-bias[dev,web]",
+]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ dev = [
     "mkdocstrings[python]>=0.29.1",
     "python-semantic-release==7.33.3",
 ]
+web = [
+    "fastapi>=0.111.0",
+    "uvicorn>=0.29.0",
+    "python-multipart>=0.0.9",
+]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/risk_of_bias/web.py
+++ b/risk_of_bias/web.py
@@ -49,7 +49,7 @@ def analyze(file: UploadFile = File(...)) -> str:
     framework: Framework = run_framework(
         manuscript=pdf_path,
         framework=get_rob2_framework(),
-        verbose=False,
+        verbose=True,
     )
 
     json_path = work_dir / "result.json"
@@ -63,7 +63,8 @@ def analyze(file: UploadFile = File(...)) -> str:
     html_content = html_path.read_text()
     download_links = (
         f"<p><a href='/download/{file_id}/result.json'>Download JSON</a> | "
-        f"<a href='/download/{file_id}/result.md'>Download Markdown</a></p>"
+        f"<a href='/download/{file_id}/result.md'>Download Markdown</a> | "
+        f"<a href='/download/{file_id}/result.html'>Download HTML</a></p>"
     )
 
     return html_content.replace("<body>", f"<body>{download_links}", 1)

--- a/risk_of_bias/web.py
+++ b/risk_of_bias/web.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import uuid
+
+from fastapi import FastAPI
+from fastapi import File
+from fastapi import HTTPException
+from fastapi import UploadFile
+from fastapi.responses import FileResponse
+from fastapi.responses import HTMLResponse
+
+from risk_of_bias.frameworks.rob2 import get_rob2_framework
+from risk_of_bias.run_framework import run_framework
+from risk_of_bias.types._framework_types import Framework
+
+APP_TEMP_DIR = Path(tempfile.gettempdir()) / "risk_of_bias_web"
+APP_TEMP_DIR.mkdir(parents=True, exist_ok=True)
+
+app = FastAPI()
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> str:
+    """Return a simple upload form."""
+    return (
+        "<html><body>"
+        "<h1>Risk of Bias Assessment</h1>"
+        "<form action='/analyze' method='post' enctype='multipart/form-data'>"
+        "<input type='file' name='file' accept='application/pdf'>"
+        "<input type='submit' value='Upload'>"
+        "</form></body></html>"
+    )
+
+
+@app.post("/analyze", response_class=HTMLResponse)
+def analyze(file: UploadFile = File(...)) -> str:
+    """Process a PDF and return the assessment HTML."""
+    file_id = uuid.uuid4().hex
+    work_dir = APP_TEMP_DIR / file_id
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = file.filename or "manuscript.pdf"
+    pdf_path = work_dir / filename
+    with pdf_path.open("wb") as f:
+        f.write(file.file.read())
+
+    framework: Framework = run_framework(
+        manuscript=pdf_path,
+        framework=get_rob2_framework(),
+        verbose=False,
+    )
+
+    json_path = work_dir / "result.json"
+    md_path = work_dir / "result.md"
+    html_path = work_dir / "result.html"
+
+    framework.save(json_path)
+    framework.export_to_markdown(md_path)
+    framework.export_to_html(html_path)
+
+    html_content = html_path.read_text()
+    download_links = (
+        f"<p><a href='/download/{file_id}/result.json'>Download JSON</a> | "
+        f"<a href='/download/{file_id}/result.md'>Download Markdown</a></p>"
+    )
+
+    return html_content.replace("<body>", f"<body>{download_links}", 1)
+
+
+@app.get("/download/{file_id}/{filename}")
+def download(file_id: str, filename: str) -> FileResponse:
+    """Return a saved file for download."""
+    file_path = APP_TEMP_DIR / file_id / filename
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_path, filename=filename)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+
+from fastapi.testclient import TestClient
+
+os.environ["OPENAI_API_KEY"] = "test"
+
+from risk_of_bias import web
+from risk_of_bias.types._framework_types import Framework
+
+
+def fake_run_framework(manuscript: Path, framework, verbose: bool = False) -> Framework:
+    result = Framework(name="Test Framework")
+    result.manuscript = Path(manuscript).name
+    return result
+
+
+def test_index_returns_form():
+    client = TestClient(web.app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "<form" in response.text
+
+
+def test_analyze_and_download(tmp_path, monkeypatch):
+    monkeypatch.setattr(web, "run_framework", fake_run_framework)
+
+    client = TestClient(web.app)
+
+    pdf = tmp_path / "manuscript.pdf"
+    pdf.write_bytes(b"dummy")
+
+    with pdf.open("rb") as f:
+        response = client.post(
+            "/analyze", files={"file": ("manuscript.pdf", f, "application/pdf")}
+        )
+
+    assert response.status_code == 200
+    assert "Download JSON" in response.text
+    assert "Download Markdown" in response.text
+
+    match = re.search(r"/download/(\w+)/result.json", response.text)
+    assert match
+    file_id = match.group(1)
+
+    download_resp = client.get(f"/download/{file_id}/result.json")
+    assert download_resp.status_code == 200
+    assert download_resp.headers["content-type"] == "application/json"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add FastAPI based upload form with download links
- document new web interface
- include FastAPI extras in project config
- update docs navigation
- add tests for the web interface

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68484223844c832a98bc4336782361a9