### PR TITLE
feat: framework summary utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,14 @@
 - Ensure all tests pass before you begin development by running `make test`
 - Ensure all linting etc is correct before you begin development by running `make lint`
 - Be aware that mypy can take a few minutes to run, don't exit it before it finishes.
+- Read the README.md and docs directory before you start development.
 
 ## Development guidelines
 - Use black style formatting.
 - Ensure every function has complete documentation using numpy style docstrings.
 - Strictly use type hinting.
 - Use perfect spelling and grammar for all documentation etc. Use Australian english.
+- Update relevant section in the docs after you complete your code changes.
 
 ## Testing Instructions
 - Find the CI plan in the .github/workflows folder.

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,5 +81,47 @@ The package provides ready-to-use frameworks that implement established risk-of-
       show_root_full_path: true
       heading_level: 4
 
+## Summary and Analysis Functions
+
+After completing individual risk-of-bias assessments using frameworks, researchers typically need to analyze results across multiple studies for systematic reviews, meta-analyses, or research synthesis. The summary functions provide essential tools for aggregating, visualizing, and exporting assessment results in formats compatible with established research workflows.
+
+These functions address three critical needs in evidence synthesis:
+
+1. **Batch Processing**: Loading and processing multiple completed assessments from saved framework files
+2. **Data Aggregation**: Extracting domain-level judgements across studies for comparative analysis  
+3. **Standardized Export**: Creating outputs compatible with specialized visualization tools like RobVis
+
+This workflow supports the transition from individual study assessment to systematic evidence synthesis, enabling researchers to identify patterns of bias across study collections and generate publication-ready visualizations for systematic reviews.
+
+### Loading Multiple Assessments
+
+::: risk_of_bias.summary.load_frameworks_from_directory
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: false
+      show_root_full_path: true
+      heading_level: 4
+
+### Creating Assessment Summaries
+
+::: risk_of_bias.summary.summarise_frameworks
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: false
+      show_root_full_path: true
+      heading_level: 4
+
+### Exporting for Visualization
+
+::: risk_of_bias.summary.export_summary
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: false
+      show_root_full_path: true
+      heading_level: 4
+
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,7 @@
 The package comes with an easy to use command line interface (CLI) tool.
 The CLI tool is installed along with the python package.
 
-## Command Line Usage
+## Command Line Interface
 
 The CLI tool provides several handy parameters you can adjust, these can be found using:
 
@@ -17,11 +17,11 @@ The CLI tool provides several handy parameters you can adjust, these can be foun
 │ --install-completion          Install completion for the current shell.        │
 │ --show-completion             Show completion for the current shell, to copy   │
 │                               it or customise the installation.                │
-│ --help                        Show this message and exit.                       │
+│ --help                        Show this message and exit.                      │
 ╰────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────╮
-│ analyse   Run risk of bias assessment on a manuscript.                         │
-│ web       Launch the web interface using uvicorn.                               │
+│ analyse   Run risk of bias assessment on a manuscript or directory             │
+│ web       Launch the web interface using uvicorn.                              │
 ╰────────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -31,8 +31,14 @@ And you can analyse a manuscript by simply passing the path to the file:
 risk-of-bias analyse /path/to/manuscript.pdf
 ```
 
-To start the web interface run:
+## Batch Analysis
+
+You can analyse an entire directory of manuscripts for systematic reviews and meta-analyses:
 
 ```console
-risk-of-bias web
+risk-of-bias analyse /path/to/manuscripts/
 ```
+
+When processing multiple manuscripts, the tool automatically generates a RobVis-compatible CSV summary file containing domain-level risk-of-bias judgements across all studies. This CSV can be directly imported into the RobVis visualization tool or used with statistical software for further analysis.
+
+For complete details on the summary functions, data formats, and programmatic access to batch analysis features, see the [API documentation](api.md#summary-and-analysis-functions).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,16 @@ Risk of bias tools are systematic frameworks primarily used in systematic review
 They aim to identify specific mechanisms through which bias might be introduced into study results, such as problems arising during the study design, conduct, or analysis.
 This package provides AI and software tools to assist researchers in conducting risk of bias analyses.
 
+### Key Features
+
+- **Advanced AI** provides robust and independent risk of bias analysis
+- **Standard Frameworks** such as RoB2 are provided out of the box
+- **Batch processing** for systematic reviews and meta-analyses
+- **Web interface** for single manuscript analysis with download options
+- **Command line interface** for integration into research workflows
+- **Latest AI models** for evidence extraction and bias assessment
+- **RobVis-compatible exports** for publication-ready visualizations
+
 
 ## Getting Started
 
@@ -43,7 +53,7 @@ But to get started, you can analyse a manuscript by simply passing the path to t
 risk-of-bias analyse /path/to/manuscript.pdf
 ```
 
-Or you can analyse an entire directory using:
+For systematic reviews, you can analyse entire directories and automatically generate RobVis-compatible CSV summaries:
 
 ```console
 risk-of-bias analyse /path/to/manuscripts/

--- a/risk_of_bias/__init__.py
+++ b/risk_of_bias/__init__.py
@@ -1,1 +1,13 @@
-# Risk of Bias Assessment
+"""Risk of Bias Assessment utilities."""
+
+from .summary import export_summary
+from .summary import load_frameworks_from_directory
+from .summary import print_summary
+from .summary import summarise_frameworks
+
+__all__ = [
+    "load_frameworks_from_directory",
+    "print_summary",
+    "export_summary",
+    "summarise_frameworks",
+]

--- a/risk_of_bias/cli.py
+++ b/risk_of_bias/cli.py
@@ -40,6 +40,10 @@ def analyse(
 
     If a JSON file with the same name as the manuscript already exists,
     it will be loaded instead of reprocessing the PDF (unless --force is used).
+
+    If a directory is provided, all PDF files within that directory will be processed,
+    and a summary CSV file will be generated containing the risk of bias assessments
+    for each manuscript that is compatible with tools such as robvis.
     """
     manuscript_path = Path(manuscript)
 

--- a/risk_of_bias/cli.py
+++ b/risk_of_bias/cli.py
@@ -6,6 +6,9 @@ import typer
 from risk_of_bias.config import settings
 from risk_of_bias.frameworks.rob2 import get_rob2_framework
 from risk_of_bias.run_framework import run_framework
+from risk_of_bias.summary import export_summary
+from risk_of_bias.summary import print_summary
+from risk_of_bias.summary import summarise_frameworks
 from risk_of_bias.types._framework_types import Framework
 
 app = typer.Typer(help="Run risk of bias assessment")
@@ -73,6 +76,13 @@ def analyse(
 
         if verbose:
             typer.echo(f"Processed {len(results)} PDF files from directory")
+
+        frameworks_summary = summarise_frameworks(results)
+        print_summary(frameworks_summary)
+        export_summary(
+            frameworks_summary,
+            path=manuscript_path / "risk_of_bias_summary.csv",
+        )
 
         # Return the last framework for consistency with single file processing
         return results[-1] if results else None

--- a/risk_of_bias/summary.py
+++ b/risk_of_bias/summary.py
@@ -11,17 +11,43 @@ from risk_of_bias.types._framework_types import Framework
 
 
 def load_frameworks_from_directory(directory: Path | str) -> List[Framework]:
-    """Load all JSON frameworks from ``directory``.
+    """Load multiple completed risk-of-bias assessments for batch analysis.
+
+    This function enables systematic reviews and meta-analyses by batch-loading
+    previously completed framework assessments from a directory. After conducting
+    individual risk-of-bias assessments on multiple studies, researchers typically
+    need to analyze patterns across their entire study collection. This function
+    streamlines that process by automatically discovering and loading all completed
+    assessments.
+
+    The function is fault-tolerant, continuing to load valid frameworks even if
+    some files are corrupted or incompatible. This robustness is essential when
+    working with large collections of assessments that may have been created over
+    time or by different researchers.
+
+    Common use cases include:
+    - Preparing data for systematic review summary tables
+    - Generating cross-study bias pattern visualizations
+    - Creating inputs for meta-analysis software
+    - Quality assurance checks across assessment batches
 
     Parameters
     ----------
     directory : Path | str
-        Directory containing previously saved framework JSON files.
+        Directory containing previously saved framework JSON files from completed
+        risk-of-bias assessments.
 
     Returns
     -------
     list[Framework]
-        List of loaded frameworks. Files that cannot be parsed are ignored.
+        List of successfully loaded frameworks. Files that cannot be parsed
+        (due to corruption, format changes, etc.) are silently ignored to
+        ensure batch processing continues.
+
+    Examples
+    --------
+    >>> frameworks = load_frameworks_from_directory("./completed_assessments/")
+    >>> print(f"Loaded {len(frameworks)} completed assessments")
     """
     path = Path(directory)
     frameworks: list[Framework] = []
@@ -36,17 +62,46 @@ def load_frameworks_from_directory(directory: Path | str) -> List[Framework]:
 def summarise_frameworks(
     frameworks: List[Framework],
 ) -> Dict[str, Dict[str, str | None]]:
-    """Create a summary representation of completed frameworks.
+    """Extract domain-level risk judgements for comparative analysis across studies.
+
+    This function transforms detailed framework assessments into a simplified summary
+    format suitable for systematic review tables, meta-analysis inputs, and cross-study
+    comparisons. By extracting only the final risk-of-bias judgements for each domain,
+    it creates a standardized view that facilitates pattern recognition and evidence
+    synthesis across multiple studies.
+
+    The function specifically looks for "Risk-of-bias judgement" questions within each
+    domain, which represent the final assessment conclusions after considering all
+    signaling questions and evidence. This approach aligns with established risk-of-bias
+    assessment methodologies where detailed questioning leads to domain-level
+    judgements.
+
+    Key applications include:
+    - Creating summary tables for systematic review publications
+    - Identifying studies with consistent bias patterns across domains
+    - Preparing data for risk-of-bias visualization tools (e.g., RobVis)
+    - Supporting meta-analysis decisions about study inclusion/weighting
 
     Parameters
     ----------
     frameworks : list[Framework]
-        Frameworks to summarise.
+        Completed framework assessments to summarise. These should contain
+        domain-level "Risk-of-bias judgement" responses.
 
     Returns
     -------
     dict[str, dict[str, str | None]]
-        Mapping of manuscript name to domain-level risk of bias judgements.
+        Nested mapping structure where:
+        - Outer keys: manuscript/study identifiers
+        - Inner keys: domain names
+        - Values: risk-of-bias judgements ("low", "some concerns", "high")
+          or None if no judgement was recorded
+
+    Examples
+    --------
+    >>> summary = summarise_frameworks(loaded_frameworks)
+    >>> print(summary["Smith2023"]["Randomization Process"])
+    'low'
     """
     summary: dict[str, dict[str, str | None]] = {}
     for fw in frameworks:
@@ -119,19 +174,45 @@ def export_summary(
     summary: Mapping[str, Mapping[str, str | None]],
     path: Path | str,
 ) -> None:
-    """Export ``summary`` to ``path`` as a CSV table.
+    """Export risk-of-bias summary to a CSV file for analysis and visualization.
 
-    The exported CSV follows the format required by tools such as RobVis,
-    containing a ``Study`` column, one column for each domain (``D1`` ... ``Dn``)
-    and an ``Overall`` column representing the highest risk rating across
-    domains.
+    This function saves the risk-of-bias assessment summary as a CSV (Comma-Separated
+    Values) file, a widely-supported standard format that can be opened in spreadsheet
+    applications like Excel, imported into statistical software like R or Python, or
+    used with specialized risk-of-bias visualization tools.
+
+    The exported CSV is specifically formatted to be compatible with RobVis, a popular
+    R package and web application for creating publication-ready risk-of-bias
+    visualizations. This ensures seamless interoperability between this tool and the
+    broader risk-of-bias assessment ecosystem. The RobVis tool can generate traffic
+    light plots and summary plots that are commonly used in systematic reviews and
+    meta-analyses.
+
+    The CSV structure includes:
+    - A ``Study`` column containing manuscript/study identifiers
+    - Domain columns (``D1``, ``D2``, ..., ``Dn``) for each risk-of-bias domain
+    - An ``Overall`` column representing the highest (worst) risk rating across all
+      domains
+
+    Risk judgements are formatted according to RobVis conventions:
+    - "Low" for low risk of bias
+    - "Some concerns" for moderate risk of bias
+    - "High" for high risk of bias
 
     Parameters
     ----------
     summary : Mapping[str, Mapping[str, str | None]]
-        Output from :func:`summarise_frameworks`.
+        Output from :func:`summarise_frameworks` containing the risk-of-bias
+        assessments.
     path : Path | str
-        Destination for the CSV file.
+        Destination file path for the CSV export. The file will be created or
+        overwritten.
+
+    Notes
+    -----
+    The exported CSV can be directly uploaded to the RobVis web interface at
+    https://www.riskofbias.info/welcome/robvis-visualization-tool or used with
+    the RobVis R package for programmatic visualization generation.
     """
 
     if not summary:

--- a/risk_of_bias/summary.py
+++ b/risk_of_bias/summary.py
@@ -148,14 +148,19 @@ def export_summary(
         )
 
         ranking = {"low": 0, "some concerns": 1, "high": 2}
-        inverse_ranking = {0: "Low", 1: "Some Concerns", 2: "High"}
+        inverse_ranking = {0: "Low", 1: "Some concerns", 2: "High"}
 
         for manuscript, domains in summary.items():
             row: list[str | None] = [manuscript]
             worst = -1
             for domain in domain_names:
                 judgement = domains.get(domain)
-                row.append(judgement)
+                # robvis requires a specific format
+                if judgement is not None:
+                    judgement_robvis = judgement.replace("Concerns", "concerns")
+                else:
+                    judgement_robvis = None
+                row.append(judgement_robvis)
                 if judgement:
                     score = ranking.get(judgement.lower(), -1)
                     if score > worst:

--- a/risk_of_bias/summary.py
+++ b/risk_of_bias/summary.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, List, Mapping
+
+from rich.console import Console
+from rich.table import Table
+
+from risk_of_bias.types._framework_types import Framework
+
+
+def load_frameworks_from_directory(directory: Path | str) -> List[Framework]:
+    """Load all JSON frameworks from ``directory``.
+
+    Parameters
+    ----------
+    directory : Path | str
+        Directory containing previously saved framework JSON files.
+
+    Returns
+    -------
+    list[Framework]
+        List of loaded frameworks. Files that cannot be parsed are ignored.
+    """
+    path = Path(directory)
+    frameworks: list[Framework] = []
+    for json_file in path.glob("*.json"):
+        try:
+            frameworks.append(Framework.load(json_file))
+        except Exception:
+            continue
+    return frameworks
+
+
+def summarise_frameworks(
+    frameworks: List[Framework],
+) -> Dict[str, Dict[str, str | None]]:
+    """Create a summary representation of completed frameworks.
+
+    Parameters
+    ----------
+    frameworks : list[Framework]
+        Frameworks to summarise.
+
+    Returns
+    -------
+    dict[str, dict[str, str | None]]
+        Mapping of manuscript name to domain-level risk of bias judgements.
+    """
+    summary: dict[str, dict[str, str | None]] = {}
+    for fw in frameworks:
+        manuscript = fw.manuscript or ""
+        domain_results: dict[str, str | None] = {}
+        for domain in fw.domains:
+            judgement = None
+            for question in domain.questions:
+                if question.question == "Risk-of-bias judgement" and question.response:
+                    judgement = question.response.response
+                    break
+            domain_results[domain.name] = judgement
+        summary[manuscript] = domain_results
+    return summary
+
+
+def print_summary(
+    summary: Mapping[str, Mapping[str, str | None]],
+    console: Console | None = None,
+) -> None:
+    """Display a summary table of risk-of-bias assessments.
+
+    Parameters
+    ----------
+    summary : Mapping[str, Mapping[str, str | None]]
+        Output from :func:`summarise_frameworks`.
+    console : Console, optional
+        Rich console used for output. If ``None``, a default console is created.
+
+    Returns
+    -------
+    None
+        ``None`` is returned after printing the table.
+    """
+
+    if console is None:
+        console = Console()
+
+    if not summary:
+        console.print("No summaries to display.")
+        return
+
+    domain_names = list(next(iter(summary.values())).keys())
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Study")
+    for i, _ in enumerate(domain_names, start=1):
+        table.add_column(f"D{i}", justify="center")
+
+    judgement_symbols = {
+        "low": "+",
+        "some concerns": "-",
+        "high": "x",
+    }
+
+    for manuscript, domains in summary.items():
+        row = [manuscript]
+        for domain in domain_names:
+            judgement = domains.get(domain)
+            symbol = judgement_symbols.get(
+                (judgement or "").lower(),
+                "?",
+            )
+            row.append(symbol)
+        table.add_row(*row)
+
+    console.print(table)
+
+
+def export_summary(
+    summary: Mapping[str, Mapping[str, str | None]],
+    path: Path | str,
+) -> None:
+    """Export ``summary`` to ``path`` as a CSV table.
+
+    The exported CSV follows the format required by tools such as RobVis,
+    containing a ``Study`` column, one column for each domain (``D1`` ... ``Dn``)
+    and an ``Overall`` column representing the highest risk rating across
+    domains.
+
+    Parameters
+    ----------
+    summary : Mapping[str, Mapping[str, str | None]]
+        Output from :func:`summarise_frameworks`.
+    path : Path | str
+        Destination for the CSV file.
+    """
+
+    if not summary:
+        Path(path).write_text("")
+        return
+
+    domain_names = list(next(iter(summary.values())).keys())
+    path = Path(path)
+
+    with path.open("w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(
+            ["Study"] + [f"D{i}" for i in range(1, len(domain_names) + 1)] + ["Overall"]
+        )
+
+        ranking = {"low": 0, "some concerns": 1, "high": 2}
+        inverse_ranking = {0: "Low", 1: "Some Concerns", 2: "High"}
+
+        for manuscript, domains in summary.items():
+            row: list[str | None] = [manuscript]
+            worst = -1
+            for domain in domain_names:
+                judgement = domains.get(domain)
+                row.append(judgement)
+                if judgement:
+                    score = ranking.get(judgement.lower(), -1)
+                    if score > worst:
+                        worst = score
+
+            overall = inverse_ranking.get(worst, "")
+            row.append(overall)
+            writer.writerow(row)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+from rich.console import Console
+
+from risk_of_bias.frameworks.rob2 import get_rob2_framework
+from risk_of_bias.summary import export_summary
+from risk_of_bias.summary import load_frameworks_from_directory
+from risk_of_bias.summary import print_summary
+from risk_of_bias.summary import summarise_frameworks
+from risk_of_bias.types._response_types import ReasonedResponseWithEvidenceAndRawData
+
+
+def test_load_frameworks_from_directory(tmp_path: Path) -> None:
+    framework = get_rob2_framework()
+    framework.manuscript = "paper1.pdf"
+    # add simple judgements
+    for domain in framework.domains:
+        for question in domain.questions:
+            if question.question == "Risk-of-bias judgement":
+                question.response = ReasonedResponseWithEvidenceAndRawData(
+                    evidence=[], reasoning="", response="Low"
+                )
+
+    json_path = tmp_path / "paper1.json"
+    framework.save(json_path)
+
+    loaded = load_frameworks_from_directory(tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].manuscript == "paper1.pdf"
+
+
+def test_summarise_frameworks(tmp_path: Path) -> None:
+    framework = get_rob2_framework()
+    framework.manuscript = "paper1.pdf"
+    for domain in framework.domains:
+        for question in domain.questions:
+            if question.question == "Risk-of-bias judgement":
+                question.response = ReasonedResponseWithEvidenceAndRawData(
+                    evidence=[], reasoning="", response="High"
+                )
+
+    summary = summarise_frameworks([framework])
+    assert "paper1.pdf" in summary
+    assessments = summary["paper1.pdf"]
+    assert len(assessments) == len(framework.domains)
+    for domain in framework.domains:
+        assert assessments[domain.name] == "High"
+
+
+def test_print_summary_outputs_table() -> None:
+    framework = get_rob2_framework()
+    framework.manuscript = "study1.pdf"
+    for domain in framework.domains:
+        for question in domain.questions:
+            if question.question == "Risk-of-bias judgement":
+                question.response = ReasonedResponseWithEvidenceAndRawData(
+                    evidence=[], reasoning="", response="Low"
+                )
+
+    summary = summarise_frameworks([framework])
+    console = Console(width=80, record=True)
+    print_summary(summary, console=console)
+    output = console.export_text()
+    assert "study1.pdf" in output
+    assert "D1" in output
+    assert "+" in output
+
+
+def test_export_summary_creates_csv(tmp_path: Path) -> None:
+    framework = get_rob2_framework()
+    framework.manuscript = "studyA.pdf"
+    for domain in framework.domains:
+        for question in domain.questions:
+            if question.question == "Risk-of-bias judgement":
+                question.response = ReasonedResponseWithEvidenceAndRawData(
+                    evidence=[], reasoning="", response="Low"
+                )
+
+    summary = summarise_frameworks([framework])
+    export_path = tmp_path / "summary.csv"
+    export_summary(summary, export_path)
+
+    content = export_path.read_text().splitlines()
+    assert content[0].startswith("Study,D1")
+    assert "studyA.pdf" in content[1]


### PR DESCRIPTION
## Summary
- add `load_frameworks_from_directory` and `summarise_frameworks` for bulk loading results
- expose summary utilities from package root
- test new functionality
- display summary tables using rich
- export summary CSV for robvis

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6848b4ca82c8832a992be051980eff71