### PR TITLE
docs: add docs page on visualisation

### DIFF
--- a/docs/visualisation.md
+++ b/docs/visualisation.md
@@ -1,0 +1,3 @@
+# Visualisation
+
+There's no need to reinvent the wheel when it comes to figures. We recommend using [robvis](https://github.com/mcguinlu/robvis) to create plots from risk-of-bias data. Our export functions generate files that robvis can read directly. See the [exporting for visualisation](api.md#exporting-for-visualization) section of the API docs for details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - Details & API: api.md
     - Command Line Interface: cli.md
     - Web Interface: web.md
+    - Visualisation: visualisation.md
     - Contributing: contributing.md
 
 


### PR DESCRIPTION
## Summary
- document that plotting is best left to `robvis`
- highlight that our exports are compatible with `robvis`
- link docs to the API section on exporting

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6848d96734e0832abaafeacbf3da51a4