### PR TITLE
feat: add macOS build workflow

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,0 +1,22 @@
+name: mac-app
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -e .[all]
+      - name: Build macOS app
+        run: make mac
+      - name: Upload artefact
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/RiskOfBias

--- a/docs/mac_app.md
+++ b/docs/mac_app.md
@@ -19,3 +19,9 @@ make mac
 
 The resulting application can be found in the `dist` directory.
 It should launch the web app after a few seconds when run.
+
+## GitHub Release Builds
+
+Each time a release is created on GitHub, an automated workflow runs
+`make mac` on a macOS runner and attaches the resulting application to
+the release. The pre-built download can be found in the release assets.


### PR DESCRIPTION
## Summary
- build macOS release binary in GitHub Actions
- document the automatic release build

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6849262c192c832a83bf6eac1dd9fde1