### PR TITLE
feat: prompt for API key in web interface

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -18,3 +18,7 @@ risk-of-bias web
 Open `http://127.0.0.1:8000` and upload your manuscript. After processing you
 will see the report along with links to download the JSON and Markdown
 representations.
+
+If the `OPENAI_API_KEY` environment variable is not set when the server
+starts, the upload form will include a field to provide it. When supplied,
+the key is used for that analysis session.

--- a/risk_of_bias/run_framework.py
+++ b/risk_of_bias/run_framework.py
@@ -12,8 +12,6 @@ from risk_of_bias.types._framework_types import Framework
 from risk_of_bias.types._response_types import create_domain_response_class
 from risk_of_bias.types._response_types import ReasonedResponseWithEvidenceAndRawData
 
-client = OpenAI()
-
 
 def run_framework(
     manuscript: Path,
@@ -22,6 +20,7 @@ def run_framework(
     guidance_document: Optional[Path] = None,
     verbose: bool = False,
     temperature: float = settings.temperature,
+    api_key: Optional[str] = None,
 ) -> Framework:
     """
     Perform systematic risk-of-bias assessment on a research manuscript using AI.
@@ -93,6 +92,9 @@ def run_framework(
     temperature : float, default=settings.temperature
         Sampling temperature passed to the OpenAI model. Higher values yield more
         diverse answers while lower values make outputs more deterministic.
+    api_key : Optional[str], default=None
+        API key to use for OpenAI calls. If ``None``, ``OPENAI_API_KEY`` from the
+        environment will be used.
 
     Returns
     -------
@@ -110,6 +112,8 @@ def run_framework(
         (Framework → Domains → Questions → Responses) for easy navigation
         and analysis of results.
     """
+
+    client = OpenAI(api_key=api_key)
 
     # Send system message to set context for the AI model
     chat_input: list[Any] = [create_openai_message("system", text=SYSTEM_MESSAGE)]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -18,6 +18,7 @@ def fake_run_framework(
     model: str,
     verbose: bool = False,
     temperature: float = 0.2,
+    api_key: str | None = None,
 ) -> Framework:
     result = Framework(name="Test Framework")
     result.manuscript = Path(manuscript).name


### PR DESCRIPTION
## Summary
- prompt for the OPENAI_API_KEY in the web UI when it's not set
- pass the optional API key through the web API
- add API key parameter to `run_framework`
- document the new behaviour in the web docs
- adjust tests for the API change

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6849239e7d30832aad0154ef095f1d18