### PR TITLE
docs: add mac release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ Then open `http://127.0.0.1:8000` and upload your manuscript.
 After processing you will see the report along with links to
 download the JSON and Markdown representations.
 
+
+### Standalone MacOS App
+
 If you prefer a standalone application, a compiled macOS version of the web
 interface is attached to every release. It processes one PDF at a time. You can
 [download the latest build here](https://github.com/rob-luke/risk-of-bias/releases/latest/download/RiskOfBias).
+The app is not signed, so you may need to go to Settings - Security - Allow Application.
 
 
 ## Frameworks

--- a/README.md
+++ b/README.md
@@ -83,9 +83,13 @@ To start the web interface run:
 risk-of-bias web
 ```
 
-Then open `http://127.0.0.1:8000` and upload your manuscript. 
+Then open `http://127.0.0.1:8000` and upload your manuscript.
 After processing you will see the report along with links to
 download the JSON and Markdown representations.
+
+If you prefer a standalone application, a compiled macOS version of the web
+interface is attached to every release. It processes one PDF at a time. You can
+[download the latest build here](https://github.com/rob-luke/risk-of-bias/releases/latest/download/RiskOfBias).
 
 
 ## Frameworks

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,6 +98,15 @@ After processing you will see the report along with links to
 download the JSON and Markdown representations.
 
 
+### Standalone MacOS App
+
+If you prefer a standalone application, a compiled macOS version of the web
+interface is attached to every release. It processes one PDF at a time. You can
+[download the latest build here](https://github.com/rob-luke/risk-of-bias/releases/latest/download/RiskOfBias).
+The app is not signed, so you may need to go to Settings - Security - Allow Application.
+
+
+
 ## Frameworks
 
 The _Risk of Bias_ tool currently only supports the RoB 2 framework.

--- a/docs/mac_app.md
+++ b/docs/mac_app.md
@@ -25,3 +25,6 @@ It should launch the web app after a few seconds when run.
 Each time a release is created on GitHub, an automated workflow runs
 `make mac` on a macOS runner and attaches the resulting application to
 the release. The pre-built download can be found in the release assets.
+The application bundles the web interface and processes a single PDF at a time.
+You can always download the most recent version from the
+[latest release](https://github.com/rob-luke/risk-of-bias/releases/latest/download/RiskOfBias).

--- a/docs/web.md
+++ b/docs/web.md
@@ -22,3 +22,7 @@ representations.
 If the `OPENAI_API_KEY` environment variable is not set when the server
 starts, the upload form will include a field to provide it. When supplied,
 the key is used for that analysis session.
+
+A standalone macOS application based on this interface is generated for each
+release. It only processes one PDF at a time and can be downloaded from the
+[latest release](https://github.com/rob-luke/risk-of-bias/releases/latest/download/RiskOfBias).


### PR DESCRIPTION
## Summary
- mention compiled mac build in README
- note release build details in docs
- link web docs to the mac release

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68494480ded0832aa270b30cb679b8e2