### PR TITLE
feat: allow optional temperature

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,7 +27,8 @@ The CLI tool provides several handy parameters you can adjust, these can be foun
 
 The `analyse` command accepts options for model selection and the sampling
 temperature. Temperature defaults to `0.2` and controls the randomness of
-the OpenAI model's responses.
+the OpenAI model's responses. Pass `--temperature none` to omit this
+parameter and use the server default.
 
 And you can analyse a manuscript by simply passing the path to the file:
 

--- a/risk_of_bias/cli.py
+++ b/risk_of_bias/cli.py
@@ -23,8 +23,9 @@ def analyse(
         help="Path to the manuscript PDF or directory containing PDFs",
     ),
     model: str = typer.Option(settings.fast_ai_model, help="OpenAI model name"),
-    temperature: float = typer.Option(
-        settings.temperature, help="Temperature for the OpenAI model"
+    temperature: Optional[str] = typer.Option(
+        None,
+        help="Temperature for the OpenAI model. Use 'none' to omit the parameter",
     ),
     guidance_document: Optional[str] = typer.Option(
         None,
@@ -63,6 +64,13 @@ def analyse(
     for each manuscript that is compatible with tools such as robvis.
     """
     manuscript_path = Path(manuscript)
+
+    if temperature is None:
+        temperature_value: Optional[float] = settings.temperature
+    elif temperature.lower() == "none":
+        temperature_value = None
+    else:
+        temperature_value = float(temperature)
 
     # If input is a directory, process all PDFs in it
     if manuscript_path.is_dir():
@@ -146,7 +154,7 @@ def analyse(
                 model=model,
                 guidance_document=guidance_document_path,
                 verbose=verbose,
-                temperature=temperature,
+                temperature=temperature_value,
             )
 
     else:
@@ -156,7 +164,7 @@ def analyse(
             model=model,
             guidance_document=guidance_document_path,
             verbose=verbose,
-            temperature=temperature,
+            temperature=temperature_value,
         )
 
         completed_framework.save(output_json_path)

--- a/risk_of_bias/run_framework.py
+++ b/risk_of_bias/run_framework.py
@@ -19,7 +19,7 @@ def run_framework(
     model: str = settings.fast_ai_model,
     guidance_document: Optional[Path] = None,
     verbose: bool = False,
-    temperature: float = settings.temperature,
+    temperature: Optional[float] = settings.temperature,
     api_key: Optional[str] = None,
 ) -> Framework:
     """
@@ -173,12 +173,19 @@ def run_framework(
 
         chat_input.append(create_openai_message("user", text=questions_text))
 
-        raw_response = client.responses.parse(
-            model=model,
-            input=chat_input,
-            text_format=domain_response_class,
-            temperature=temperature,
-        )
+        if temperature is None:
+            raw_response = client.responses.parse(
+                model=model,
+                input=chat_input,
+                text_format=domain_response_class,
+            )
+        else:
+            raw_response = client.responses.parse(
+                model=model,
+                input=chat_input,
+                text_format=domain_response_class,
+                temperature=temperature,
+            )
         parsed_response = raw_response.output_parsed
 
         chat_input.append(

--- a/tests/test_run_framework.py
+++ b/tests/test_run_framework.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import types
+
+from risk_of_bias.frameworks.rob2 import get_rob2_framework
+import risk_of_bias.run_framework as rf
+
+
+def test_run_framework_omits_temperature(tmp_path, monkeypatch):
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"dummy")
+
+    captured = {}
+
+    class FakeResponses:
+        def parse(self, **kwargs):
+            captured.update(kwargs)
+            return types.SimpleNamespace(output_parsed=None, output_text="x")
+
+    class FakeClient:
+        def __init__(self, api_key=None):
+            self.responses = FakeResponses()
+
+    monkeypatch.setattr(rf, "OpenAI", lambda api_key=None: FakeClient())
+    monkeypatch.setattr(rf, "pdf_to_base64", lambda p: "data")
+    monkeypatch.setattr(rf, "create_domain_response_class", lambda d: object)
+
+    framework = get_rob2_framework()
+    framework.domains = framework.domains[:1]
+
+    rf.run_framework(manuscript=pdf, framework=framework, temperature=None)
+    assert "temperature" not in captured
+
+    captured.clear()
+    rf.run_framework(manuscript=pdf, framework=framework, temperature=0.7)
+    assert captured.get("temperature") == 0.7


### PR DESCRIPTION
## Summary
- allow `None` to omit temperature parameter in `run_framework`
- update CLI to accept `--temperature none`
- document new CLI behaviour
- test optional temperature handling

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684a25208324832abfc2a49c616b3549