### PR TITLE
feat: provide mechanism to not send temperature values

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,23 @@ But to get started, you can analyse a manuscript by simply passing the path to t
 risk-of-bias analyse /path/to/manuscript.pdf
 ```
 
-For domain-specific assessments or to correct systematic AI biases, you can provide a guidance document:
+You can set the model and parameters. For example, to use a fast and cheap model for testing:
+
+```console
+risk-of-bias analyse --model gpt-4.1-nano /path/to/manuscript.pdf
+
+```
+
+And when you are ready to run a state of the art model, you can switch to a reasoning model.
+Reasoning models do not use the temperature parameter, so we set it to a negative number to disable it.
+
+```console
+risk-of-bias analyse --model o3 --temperature -1 /path/to/manuscript.pdf
+```
+
+For domain-specific assessments or to correct systematic AI biases, you can provide a guidance document.
+For example, if you are using the RoB2 framework you can include the 72 page additional guidance material.
+This is achieved using the `guidance-document` parameter:
 
 ```console
 risk-of-bias analyse /path/to/manuscript.pdf --guidance-document /path/to/guidance.pdf
@@ -40,16 +56,6 @@ risk-of-bias analyse /path/to/manuscript.pdf --guidance-document /path/to/guidan
 
 The results will be saved next to the pdf as a json, html, and markdown file.
 
-### JSON Data Storage and Reuse
-
-Results are automatically saved in JSON format containing the complete assessment data, including raw AI responses, evidence excerpts, and reasoning. This JSON storage serves multiple purposes:
-
-- **Efficiency**: When re-running analysis on directories, previously analyzed files are automatically detected and loaded from JSON, avoiding redundant AI calls
-- **Data sharing**: JSON files provide a standardized format for sharing complete assessment results with colleagues or across research teams  
-- **Reproducibility**: Raw response data is preserved, enabling verification and reanalysis of assessments
-- **Batch processing**: Essential for systematic reviews where hundreds of papers need processing across multiple sessions
-
-To force re-analysis of previously processed files, delete the corresponding JSON files or use the `--force` flag.
 The output will look something like:
 
 ```text
@@ -76,6 +82,19 @@ Domain 1: Bias arising from the randomization process.
 
 ...
 ```
+
+
+### JSON Data Storage and Reuse
+
+Results are automatically saved in JSON format containing the complete assessment data, including raw AI responses, evidence excerpts, and reasoning. This JSON storage serves multiple purposes:
+
+- **Efficiency**: When re-running analysis on directories, previously analyzed files are automatically detected and loaded from JSON, avoiding redundant AI calls
+- **Data sharing**: JSON files provide a standardized format for sharing complete assessment results with colleagues or across research teams  
+- **Reproducibility**: Raw response data is preserved, enabling verification and reanalysis of assessments
+- **Batch processing**: Essential for systematic reviews where hundreds of papers need processing across multiple sessions
+
+To force re-analysis of previously processed files, delete the corresponding JSON files or use the `--force` flag.
+
 
 
 Or you can analyse an entire directory using:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,7 +27,8 @@ The CLI tool provides several handy parameters you can adjust, these can be foun
 
 The `analyse` command accepts options for model selection and the sampling
 temperature. Temperature defaults to `0.2` and controls the randomness of
-the OpenAI model's responses.
+the OpenAI model's responses. If a negative value is supplied the
+temperature setting is omitted, and the server default is used instead.
 
 And you can analyse a manuscript by simply passing the path to the file:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,23 @@ But to get started, you can analyse a manuscript by simply passing the path to t
 risk-of-bias analyse /path/to/manuscript.pdf
 ```
 
-For domain-specific assessments or to address systematic AI interpretation issues, you can provide a guidance document:
+You can set the model and parameters. For example, to use a fast and cheap model for testing:
+
+```console
+risk-of-bias analyse --model gpt-4.1-nano /path/to/manuscript.pdf
+
+```
+
+And when you are ready to run a state of the art model, you can switch to a reasoning model.
+Reasoning models do not use the temperature parameter, so we set it to a negative number to disable it.
+
+```console
+risk-of-bias analyse --model o3 --temperature -1 /path/to/manuscript.pdf
+```
+
+For domain-specific assessments or to correct systematic AI biases, you can provide a guidance document.
+For example, if you are using the RoB2 framework you can include the 72 page additional guidance material.
+This is achieved using the `guidance-document` parameter:
 
 ```console
 risk-of-bias analyse /path/to/manuscript.pdf --guidance-document /path/to/guidance.pdf
@@ -49,16 +65,6 @@ risk-of-bias analyse /path/to/manuscript.pdf --guidance-document /path/to/guidan
 
 The results will be saved next to the pdf as a json, html, and markdown file.
 
-### JSON Data Storage and Reuse
-
-Results are automatically saved in JSON format containing the complete assessment data, including raw AI responses, evidence excerpts, and reasoning. This JSON storage serves multiple purposes:
-
-- **Efficiency**: When re-running analysis on directories, previously analyzed files are automatically detected and loaded from JSON, avoiding redundant AI calls
-- **Data sharing**: JSON files provide a standardized format for sharing complete assessment results with colleagues or across research teams  
-- **Reproducibility**: Raw response data is preserved, enabling verification and reanalysis of assessments
-- **Batch processing**: Essential for systematic reviews where hundreds of papers need processing across multiple sessions
-
-To force re-analysis of previously processed files, delete the corresponding JSON files or use the `--force` flag.
 The output will look something like:
 
 ```text
@@ -86,6 +92,16 @@ Domain 1: Bias arising from the randomization process.
 ...
 ```
 
+### JSON Data Storage and Reuse
+
+Results are automatically saved in JSON format containing the complete assessment data, including raw AI responses, evidence excerpts, and reasoning. This JSON storage serves multiple purposes:
+
+- **Efficiency**: When re-running analysis on directories, previously analyzed files are automatically detected and loaded from JSON, avoiding redundant AI calls
+- **Data sharing**: JSON files provide a standardized format for sharing complete assessment results with colleagues or across research teams  
+- **Reproducibility**: Raw response data is preserved, enabling verification and reanalysis of assessments
+- **Batch processing**: Essential for systematic reviews where hundreds of papers need processing across multiple sessions
+
+To force re-analysis of previously processed files, delete the corresponding JSON files or use the `--force` flag.
 
 For systematic reviews, you can analyse entire directories and automatically generate RobVis-compatible CSV summaries:
 

--- a/risk_of_bias/run_framework.py
+++ b/risk_of_bias/run_framework.py
@@ -91,7 +91,9 @@ def run_framework(
         process in detail.
     temperature : float, default=settings.temperature
         Sampling temperature passed to the OpenAI model. Higher values yield more
-        diverse answers while lower values make outputs more deterministic.
+        diverse answers while lower values make outputs more deterministic. If a
+        negative value is provided, the temperature parameter is omitted and the
+        server default is used.
     api_key : Optional[str], default=None
         API key to use for OpenAI calls. If ``None``, ``OPENAI_API_KEY`` from the
         environment will be used.
@@ -173,12 +175,15 @@ def run_framework(
 
         chat_input.append(create_openai_message("user", text=questions_text))
 
-        raw_response = client.responses.parse(
-            model=model,
-            input=chat_input,
-            text_format=domain_response_class,
-            temperature=temperature,
-        )
+        parse_kwargs: dict[str, Any] = {
+            "model": model,
+            "input": chat_input,
+            "text_format": domain_response_class,
+        }
+        if temperature >= 0:
+            parse_kwargs["temperature"] = temperature
+
+        raw_response = client.responses.parse(**parse_kwargs)
         parsed_response = raw_response.output_parsed
 
         chat_input.append(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,37 @@ def test_cli_override_temperature(tmp_path, monkeypatch):
     assert called["temperature"] == 0.7
 
 
+def test_cli_negative_temperature(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from risk_of_bias import cli
+
+    called = {}
+
+    def fake_run_framework(
+        manuscript,
+        model: str,
+        framework,
+        guidance_document,
+        verbose: bool = False,
+        temperature: float = settings.temperature,
+    ):
+        called["temperature"] = temperature
+        from risk_of_bias.types._framework_types import Framework
+
+        return Framework(name="dummy")
+
+    monkeypatch.setattr(cli, "run_framework", fake_run_framework)
+
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"dummy")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["analyse", str(pdf), "--temperature", "-1"])
+
+    assert result.exit_code == 0
+    assert called["temperature"] == -1
+
+
 def test_cli_sets_manuscript_filename(tmp_path, monkeypatch):
     """Test that the CLI properly sets the manuscript filename in the framework."""
     monkeypatch.setenv("OPENAI_API_KEY", "test")

--- a/tests/test_run_framework.py
+++ b/tests/test_run_framework.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+from risk_of_bias import run_framework
+from risk_of_bias.types._domain_types import Domain
+from risk_of_bias.types._framework_types import Framework
+from risk_of_bias.types._question_types import Question
+
+
+def test_run_framework_omits_negative_temperature(tmp_path, monkeypatch):
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"dummy")
+
+    parse_kwargs = {}
+
+    class DummyResponses:
+        def parse(self, **kwargs):
+            parse_kwargs.update(kwargs)
+            return SimpleNamespace(output_parsed=None, output_text="")
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            self.responses = DummyResponses()
+
+    monkeypatch.setattr(run_framework, "OpenAI", lambda api_key=None: DummyClient())
+    monkeypatch.setattr(run_framework, "pdf_to_base64", lambda path: "encoded")
+    monkeypatch.setattr(
+        run_framework, "create_openai_message", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr(
+        run_framework, "create_domain_response_class", lambda domain: object
+    )
+
+    framework = Framework(
+        name="Test Framework",
+        domains=[Domain(name="D1", index=1, questions=[Question(question="Q1")])],
+    )
+
+    run_framework.run_framework(
+        manuscript=pdf,
+        framework=framework,
+        temperature=-1.0,
+    )
+
+    assert "temperature" not in parse_kwargs


### PR DESCRIPTION
## Summary
- omit temperature from OpenAI call when the provided value is negative
- explain negative temperature usage in docs
- test that CLI handles negative values and run_framework omits the parameter

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684a29da7c28832a99f9c37712bc380b