### PR TITLE
feat: add human entry mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,16 @@ Results are automatically saved in JSON format containing the complete assessmen
 To force re-analysis of previously processed files, delete the corresponding JSON files or use the `--force` flag.
 
 
-
 Or you can analyse an entire directory using:
 
 ```console
 risk-of-bias analyse /path/to/manuscripts/
+```
+
+For manual entry of human assessments, you can use the `human` command to record your own risk of bias evaluations in a standardized format, enabling direct comparison with AI assessments and ensuring reproducible data storage:
+
+```console
+risk-of-bias human /path/to/manuscript.pdf
 ```
 
 
@@ -146,7 +151,6 @@ AI does not replace human judgment in risk of bias assessment. Instead, these to
 
 
 ## References
-
 
 ```
 Sterne JAC, Savović J, Page MJ, Elbers RG, Blencowe NS, Boutron I, Cates CJ,

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,16 @@ The package provides ready-to-use frameworks that implement established risk-of-
       show_root_full_path: true
       heading_level: 4
 
+### Manual Entry
+
+::: risk_of_bias.human.run_human_framework
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: false
+      show_root_full_path: true
+      heading_level: 4
+
 ### Domain
 
 ::: risk_of_bias.types.Domain

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,15 +38,7 @@ And you can analyse a manuscript by simply passing the path to the file:
 risk-of-bias analyse /path/to/manuscript.pdf
 ```
 
-### Manual Entry
-
-If you prefer to record answers yourself, use the `human` command:
-
-```console
-risk-of-bias human /path/to/manuscript.pdf
-```
-
-### Evaluating Research Protocols
+### Risk of Bias Analysis on Manuscript PDF
 
 You can run the same command on a draft protocol prior to starting a study:
 
@@ -94,6 +86,20 @@ risk-of-bias analyse /path/to/manuscripts/
 ```
 
 When processing multiple manuscripts, the tool automatically generates a RobVis-compatible CSV summary file containing domain-level risk-of-bias judgements across all studies. This CSV can be directly imported into the RobVis visualization tool or used with statistical software for further analysis.
+
+
+## Manual/Human Entry
+
+This tool can also be used to enter and store human risk of bias assessments in a standard
+reproducible file format. This is useful for sharing and storage of results, but also for
+enabling automatic comparison to the AI risk of bias assessment.
+
+If you prefer to record answers yourself, use the `human` command:
+
+```console
+risk-of-bias human /path/to/manuscript.pdf
+```
+
 
 ## JSON Data Storage and Caching
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,8 @@ The CLI tool provides several handy parameters you can adjust, these can be foun
 ╰────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────╮
 │ analyse   Run risk of bias assessment on a manuscript or directory             │
+│ human     Enter risk of bias results manually
+ │
 │ web       Launch the web interface using uvicorn.                              │
 ╰────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -34,6 +36,14 @@ And you can analyse a manuscript by simply passing the path to the file:
 
 ```console
 risk-of-bias analyse /path/to/manuscript.pdf
+```
+
+### Manual Entry
+
+If you prefer to record answers yourself, use the `human` command:
+
+```console
+risk-of-bias human /path/to/manuscript.pdf
 ```
 
 ### Evaluating Research Protocols

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,6 +109,12 @@ For systematic reviews, you can analyse entire directories and automatically gen
 risk-of-bias analyse /path/to/manuscripts/
 ```
 
+For manual entry of human assessments, you can use the `human` command to record your own risk of bias evaluations in a standardized format, enabling direct comparison with AI assessments and ensuring reproducible data storage:
+
+```console
+risk-of-bias human /path/to/manuscript.pdf
+```
+
 Further details on summarising results are found in the [API docs](api.md#summary-and-analysis-functions).
 
 ### Web Interface
@@ -147,7 +153,6 @@ AI does not replace human judgment in risk of bias assessment. Instead, these to
 
 
 ## References
-
 
 ```
 Sterne JAC, Savović J, Page MJ, Elbers RG, Blencowe NS, Boutron I, Cates CJ,

--- a/risk_of_bias/human.py
+++ b/risk_of_bias/human.py
@@ -43,6 +43,10 @@ def run_human_framework(
 
     framework.manuscript = manuscript.name
 
+    # Ask for assessor name
+    assessor_name = console.input("Enter assessor name (human): ")
+    framework.assessor = assessor_name if assessor_name.strip() else "human"
+
     for domain in framework.domains:
         console.rule(f"Domain {domain.index}: {domain.name}")
         for question in domain.questions:
@@ -52,11 +56,18 @@ def run_human_framework(
             response_text: Optional[str] = None
             while response_text is None:
                 if question.allowed_answers:
+                    # Multiple choice question - user must select from options
                     table = Table(show_header=False)
                     for i, option in enumerate(question.allowed_answers, start=1):
                         table.add_row(str(i), option)
                     console.print(table)
-                    user_input = console.input("Select option (number or text): ")
+
+                    question_text = "Select option (number) "
+                    if not question.is_required:
+                        question_text += "[optional, press enter to skip]"
+                    question_text += ": "
+
+                    user_input = console.input(question_text)
                     if user_input == "" and not question.is_required:
                         break
                     if user_input.isdigit() and 1 <= int(user_input) <= len(
@@ -66,12 +77,18 @@ def run_human_framework(
                     elif user_input in question.allowed_answers:
                         response_text = user_input
                     else:
-                        console.print("Invalid response. Please try again.")
+                        console.print("Invalid response. Please select a valid option.")
                 else:
-                    user_input = console.input("Response: ")
+                    # Free text question - user can enter any string
+                    question_text = "Response "
+                    if not question.is_required:
+                        question_text += "[optional, press enter to skip]"
+                    question_text += ": "
+
+                    user_input = console.input(question_text)
                     if user_input == "" and not question.is_required:
                         break
-                    if user_input == "":
+                    elif user_input == "" and question.is_required:
                         console.print("Response required.")
                     else:
                         response_text = user_input

--- a/risk_of_bias/human.py
+++ b/risk_of_bias/human.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+from rich.table import Table
+
+from risk_of_bias.frameworks import get_rob2_framework
+from risk_of_bias.types._framework_types import Framework
+from risk_of_bias.types._response_types import ReasonedResponseWithEvidenceAndRawData
+
+
+def run_human_framework(
+    manuscript: Path,
+    framework: Framework = get_rob2_framework(),
+    console: Optional[Console] = None,
+) -> Framework:
+    """Interactively complete a risk-of-bias framework.
+
+    This function guides the user through each question in the framework using
+    a Rich console. Users select or type responses and may provide optional
+    reasoning and evidence. Required questions must be answered; optional
+    questions can be skipped by pressing Enter. Reasoning and evidence prompts
+    can also be skipped with Enter.
+
+    Parameters
+    ----------
+    manuscript : Path
+        Path to the manuscript being assessed. Only the file name is stored in
+        the resulting framework.
+    framework : Framework, default=get_rob2_framework()
+        Framework to populate with user responses.
+    console : Console, optional
+        Console instance for input and output. A new one is created if ``None``.
+
+    Returns
+    -------
+    Framework
+        The provided framework populated with user responses.
+    """
+
+    if console is None:
+        console = Console()
+
+    framework.manuscript = manuscript.name
+
+    for domain in framework.domains:
+        console.rule(f"Domain {domain.index}: {domain.name}")
+        for question in domain.questions:
+            console.print(
+                f"[bold]Question {question.index}:[/bold] {question.question}"
+            )
+            response_text: Optional[str] = None
+            while response_text is None:
+                if question.allowed_answers:
+                    table = Table(show_header=False)
+                    for i, option in enumerate(question.allowed_answers, start=1):
+                        table.add_row(str(i), option)
+                    console.print(table)
+                    user_input = console.input("Select option (number or text): ")
+                    if user_input == "" and not question.is_required:
+                        break
+                    if user_input.isdigit() and 1 <= int(user_input) <= len(
+                        question.allowed_answers
+                    ):
+                        response_text = question.allowed_answers[int(user_input) - 1]
+                    elif user_input in question.allowed_answers:
+                        response_text = user_input
+                    else:
+                        console.print("Invalid response. Please try again.")
+                else:
+                    user_input = console.input("Response: ")
+                    if user_input == "" and not question.is_required:
+                        break
+                    if user_input == "":
+                        console.print("Response required.")
+                    else:
+                        response_text = user_input
+
+            if response_text is None:
+                continue
+
+            reasoning = console.input("Reasoning (optional): ")
+            evidence_input = console.input("Evidence (optional): ")
+            evidence = [evidence_input] if evidence_input else []
+
+            question.response = ReasonedResponseWithEvidenceAndRawData(
+                response=response_text,
+                reasoning=reasoning,
+                evidence=evidence,
+                raw_data=None,
+            )
+
+    return framework

--- a/risk_of_bias/run_framework.py
+++ b/risk_of_bias/run_framework.py
@@ -121,8 +121,9 @@ def run_framework(
     # Send system message to set context for the AI model
     chat_input: list[Any] = [create_openai_message("system", text=SYSTEM_MESSAGE)]
 
-    # Set the manuscript filename on the framework
+    # Set the manuscript filename and model name on the framework
     framework.manuscript = manuscript.name
+    framework.assessor = model
 
     # Send the framework guidance to the AI model
     if guidance_document is not None:

--- a/risk_of_bias/types/_framework_types.py
+++ b/risk_of_bias/types/_framework_types.py
@@ -31,11 +31,16 @@ class Framework(BaseModel):
         Randomized Trials").
     manuscript : str, optional
         The filename (without path) of the manuscript being assessed.
+    assessor : str | None
+        The name or identifier of the person or system performing the assessment.
+        This can be useful for tracking who completed the assessment, especially
+        in collaborative environments.
     """
 
     domains: list[Domain] = []
     name: str = ""
     manuscript: Optional[str] = None
+    assessor: Optional[str] = None
 
     def __str__(self) -> str:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,3 +307,29 @@ def test_cli_analyse_directory_processes_all_pdfs(tmp_path, monkeypatch):
         assert (pdf.with_suffix(pdf.suffix + ".json")).exists()
         assert (pdf.with_suffix(pdf.suffix + ".md")).exists()
         assert (pdf.with_suffix(pdf.suffix + ".html")).exists()
+
+
+def test_cli_human_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from risk_of_bias import cli
+    from risk_of_bias.types._framework_types import Framework
+
+    called = {}
+
+    def fake_run_human_framework(manuscript, framework):
+        called["manuscript"] = manuscript
+        result = Framework(name="dummy")
+        result.manuscript = manuscript.name
+        return result
+
+    monkeypatch.setattr(cli, "run_human_framework", fake_run_human_framework)
+
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"dummy")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["human", str(pdf)])
+
+    assert result.exit_code == 0
+    assert called["manuscript"] == pdf
+    assert (pdf.with_suffix(pdf.suffix + ".json")).exists()

--- a/tests/test_human.py
+++ b/tests/test_human.py
@@ -18,12 +18,13 @@ def test_run_human_framework_records_responses(monkeypatch):
     )
     framework = Framework(name="Test", domains=[domain])
 
-    inputs = iter(["1", "Because", "Evidence"])
+    inputs = iter(["TestAssessor", "1", "Because", "Evidence"])
     console = Console()
     monkeypatch.setattr(console, "input", lambda *args, **kwargs: next(inputs))
 
     run_human_framework(Path("manuscript.pdf"), framework, console=console)
 
+    assert framework.assessor == "TestAssessor"
     response = framework.domains[0].questions[0].response
     assert response is not None
     assert response.response == "Yes"
@@ -46,10 +47,11 @@ def test_run_human_framework_skips_optional(monkeypatch):
     )
     framework = Framework(name="Test", domains=[domain])
 
-    inputs = iter([""])
+    inputs = iter(["TestAssessor", ""])
     console = Console()
     monkeypatch.setattr(console, "input", lambda *args, **kwargs: next(inputs))
 
     run_human_framework(Path("manuscript.pdf"), framework, console=console)
 
+    assert framework.assessor == "TestAssessor"
     assert framework.domains[0].questions[0].response is None

--- a/tests/test_human.py
+++ b/tests/test_human.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from rich.console import Console
+
+from risk_of_bias.human import run_human_framework
+from risk_of_bias.types._domain_types import Domain
+from risk_of_bias.types._framework_types import Framework
+from risk_of_bias.types._question_types import Question
+
+
+def test_run_human_framework_records_responses(monkeypatch):
+    domain = Domain(
+        name="D1",
+        index=1,
+        questions=[
+            Question(question="Did it work?", allowed_answers=["Yes", "No"], index=1.0)
+        ],
+    )
+    framework = Framework(name="Test", domains=[domain])
+
+    inputs = iter(["1", "Because", "Evidence"])
+    console = Console()
+    monkeypatch.setattr(console, "input", lambda *args, **kwargs: next(inputs))
+
+    run_human_framework(Path("manuscript.pdf"), framework, console=console)
+
+    response = framework.domains[0].questions[0].response
+    assert response is not None
+    assert response.response == "Yes"
+    assert response.reasoning == "Because"
+    assert response.evidence == ["Evidence"]
+
+
+def test_run_human_framework_skips_optional(monkeypatch):
+    domain = Domain(
+        name="D1",
+        index=1,
+        questions=[
+            Question(
+                question="Optional?",
+                allowed_answers=["Yes", "No"],
+                index=1.0,
+                is_required=False,
+            )
+        ],
+    )
+    framework = Framework(name="Test", domains=[domain])
+
+    inputs = iter([""])
+    console = Console()
+    monkeypatch.setattr(console, "input", lambda *args, **kwargs: next(inputs))
+
+    run_human_framework(Path("manuscript.pdf"), framework, console=console)
+
+    assert framework.domains[0].questions[0].response is None


### PR DESCRIPTION
## Summary
- add `run_human_framework` for entering results manually
- expose new `human` CLI command
- document manual entry mode in docs
- include tests for manual workflow

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684a3d8792c8832aa9ff067c588419e6