### PR TITLE
feat: add framework comparison utility

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,5 +133,15 @@ This workflow supports the transition from individual study assessment to system
       show_root_full_path: true
       heading_level: 4
 
+### Comparing Assessors
+
+::: risk_of_bias.compare.compare_frameworks
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: false
+      show_root_full_path: true
+      heading_level: 4
+
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,7 @@ risk-of-bias human /path/to/manuscript.pdf
 ```
 
 Further details on summarising results are found in the [API docs](api.md#summary-and-analysis-functions).
+Instructions for comparing two assessors are detailed in the [API docs](api.md#comparing-assessors).
 
 ### Web Interface
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ risk-of-bias human /path/to/manuscript.pdf
 ```
 
 Further details on summarising results are found in the [API docs](api.md#summary-and-analysis-functions).
-Instructions for comparing two assessors are detailed in the [API docs](api.md#comparing-assessors).
+Instructions for comparing two assessors are detailed in the [API docs](api.md#comparing-assessors). The comparison output includes short domain and question labels (e.g., `D1`, `Q1.1`) for quick reference.
 
 ### Web Interface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "openai>=1.84.0",
     "typer>=0.12.3",
     "htpy>=25.6.2",
+    "pandas>=2.2.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "mkdocstrings[python]>=0.29.1",
     "python-semantic-release==7.33.3",
     "pyinstaller>=6.14.1",
+    "pandas-stubs",
 ]
 web = [
     "fastapi>=0.111.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-pydantic>=2.11.4
-pydantic-settings>=2.9.1
-openai>=1.84.0
-typer>=0.12.3
-htpy>=25.6.2
-fastapi>=0.111.0
-uvicorn>=0.29.0
-python-multipart>=0.0.9

--- a/risk_of_bias/__init__.py
+++ b/risk_of_bias/__init__.py
@@ -1,5 +1,6 @@
 """Risk of Bias Assessment utilities."""
 
+from .compare import compare_frameworks
 from .summary import export_summary
 from .summary import load_frameworks_from_directory
 from .summary import print_summary
@@ -10,4 +11,5 @@ __all__ = [
     "print_summary",
     "export_summary",
     "summarise_frameworks",
+    "compare_frameworks",
 ]

--- a/risk_of_bias/compare.py
+++ b/risk_of_bias/compare.py
@@ -19,9 +19,9 @@ def compare_frameworks(fw1: Framework, fw2: Framework) -> pd.DataFrame:
     Returns
     -------
     pandas.DataFrame
-        Long-form table with ``domain``, ``question`` and one column per
-        assessor containing their responses. If a question was unanswered,
-        the value will be ``None``.
+        Long-form table with ``domain_short``, ``question_short``, ``domain``,
+        ``question`` and one column per assessor containing their responses.
+        If a question was unanswered, the value will be ``None``.
     """
 
     assessor1 = fw1.assessor or "assessor_1"
@@ -46,6 +46,8 @@ def compare_frameworks(fw1: Framework, fw2: Framework) -> pd.DataFrame:
             a2 = q2.response.response if q2.response else None
             rows.append(
                 {
+                    "domain_short": f"D{int(d1.index)}",
+                    "question_short": f"Q{q1.index}",
                     "domain": d1.name,
                     "question": q1.question,
                     assessor1: a1,

--- a/risk_of_bias/compare.py
+++ b/risk_of_bias/compare.py
@@ -1,0 +1,56 @@
+"""Utilities for comparing risk-of-bias assessments."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from risk_of_bias.types._framework_types import Framework
+
+
+def compare_frameworks(fw1: Framework, fw2: Framework) -> pd.DataFrame:
+    """Compare two completed risk-of-bias frameworks.
+
+    Parameters
+    ----------
+    fw1, fw2 : Framework
+        Completed risk-of-bias frameworks to compare. The domain and question
+        structure must be identical between the two frameworks.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Long-form table with ``domain``, ``question`` and one column per
+        assessor containing their responses. If a question was unanswered,
+        the value will be ``None``.
+    """
+
+    assessor1 = fw1.assessor or "assessor_1"
+    assessor2 = fw2.assessor or "assessor_2"
+
+    rows: list[dict[str, str | None]] = []
+    if len(fw1.domains) != len(fw2.domains):
+        raise ValueError("Frameworks have different numbers of domains")
+
+    for d1, d2 in zip(fw1.domains, fw2.domains):
+        if d1.name != d2.name:
+            raise ValueError("Domain names do not match")
+        if len(d1.questions) != len(d2.questions):
+            raise ValueError(f"Domain {d1.name} has different numbers of questions")
+        for q1, q2 in zip(d1.questions, d2.questions):
+            if q1.question != q2.question:
+                raise ValueError(
+                    "Questions do not match in domain "
+                    f"{d1.name}: {q1.question} vs {q2.question}"
+                )
+            a1 = q1.response.response if q1.response else None
+            a2 = q2.response.response if q2.response else None
+            rows.append(
+                {
+                    "domain": d1.name,
+                    "question": q1.question,
+                    assessor1: a1,
+                    assessor2: a2,
+                }
+            )
+
+    return pd.DataFrame(rows)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -9,10 +9,22 @@ def test_compare_frameworks() -> None:
     fw1.domains[0].questions[0].response = ReasonedResponseWithEvidenceAndRawData(
         evidence=[], reasoning="", response="Yes"
     )
+    fw1.domains[0].questions[1].response = ReasonedResponseWithEvidenceAndRawData(
+        evidence=[], reasoning="", response="Yes"
+    )
+    fw1.domains[1].questions[0].response = ReasonedResponseWithEvidenceAndRawData(
+        evidence=[], reasoning="", response="No"
+    )
 
     fw2 = get_rob2_framework()
     fw2.assessor = "Reviewer 2"
     fw2.domains[0].questions[0].response = ReasonedResponseWithEvidenceAndRawData(
+        evidence=[], reasoning="", response="No"
+    )
+    fw2.domains[0].questions[1].response = ReasonedResponseWithEvidenceAndRawData(
+        evidence=[], reasoning="", response="Yes"
+    )
+    fw2.domains[1].questions[0].response = ReasonedResponseWithEvidenceAndRawData(
         evidence=[], reasoning="", response="No"
     )
 
@@ -25,4 +37,18 @@ def test_compare_frameworks() -> None:
     first_row = df.iloc[0]
     assert first_row["Reviewer 1"] == "Yes"
     assert first_row["Reviewer 2"] == "No"
+
+    second_row = df[
+        (df["domain"] == fw1.domains[0].name)
+        & (df["question"] == fw1.domains[0].questions[1].question)
+    ].iloc[0]
+    assert second_row["Reviewer 1"] == "Yes"
+    assert second_row["Reviewer 2"] == "Yes"
+
+    third_row = df[
+        (df["domain"] == fw1.domains[1].name)
+        & (df["question"] == fw1.domains[1].questions[0].question)
+    ].iloc[0]
+    assert third_row["Reviewer 1"] == "No"
+    assert third_row["Reviewer 2"] == "No"
     assert len(df) == sum(len(d.questions) for d in fw1.domains)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -30,11 +30,18 @@ def test_compare_frameworks() -> None:
 
     df = compare_frameworks(fw1, fw2)
 
-    assert list(df.columns[:2]) == ["domain", "question"]
+    assert list(df.columns[:4]) == [
+        "domain_short",
+        "question_short",
+        "domain",
+        "question",
+    ]
     assert "Reviewer 1" in df.columns
     assert "Reviewer 2" in df.columns
 
     first_row = df.iloc[0]
+    assert first_row["domain_short"] == "D1"
+    assert first_row["question_short"] == "Q1.1"
     assert first_row["Reviewer 1"] == "Yes"
     assert first_row["Reviewer 2"] == "No"
 
@@ -42,6 +49,8 @@ def test_compare_frameworks() -> None:
         (df["domain"] == fw1.domains[0].name)
         & (df["question"] == fw1.domains[0].questions[1].question)
     ].iloc[0]
+    assert second_row["domain_short"] == "D1"
+    assert second_row["question_short"] == "Q1.2"
     assert second_row["Reviewer 1"] == "Yes"
     assert second_row["Reviewer 2"] == "Yes"
 
@@ -49,6 +58,8 @@ def test_compare_frameworks() -> None:
         (df["domain"] == fw1.domains[1].name)
         & (df["question"] == fw1.domains[1].questions[0].question)
     ].iloc[0]
+    assert third_row["domain_short"] == "D2"
+    assert third_row["question_short"] == "Q2.1"
     assert third_row["Reviewer 1"] == "No"
     assert third_row["Reviewer 2"] == "No"
     assert len(df) == sum(len(d.questions) for d in fw1.domains)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -30,6 +30,8 @@ def test_compare_frameworks() -> None:
 
     df = compare_frameworks(fw1, fw2)
 
+    print(df)
+
     assert list(df.columns[:4]) == [
         "domain_short",
         "question_short",
@@ -63,3 +65,5 @@ def test_compare_frameworks() -> None:
     assert third_row["Reviewer 1"] == "No"
     assert third_row["Reviewer 2"] == "No"
     assert len(df) == sum(len(d.questions) for d in fw1.domains)
+
+test_compare_frameworks()

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,28 @@
+from risk_of_bias.compare import compare_frameworks
+from risk_of_bias.frameworks.rob2 import get_rob2_framework
+from risk_of_bias.types._response_types import ReasonedResponseWithEvidenceAndRawData
+
+
+def test_compare_frameworks() -> None:
+    fw1 = get_rob2_framework()
+    fw1.assessor = "Reviewer 1"
+    fw1.domains[0].questions[0].response = ReasonedResponseWithEvidenceAndRawData(
+        evidence=[], reasoning="", response="Yes"
+    )
+
+    fw2 = get_rob2_framework()
+    fw2.assessor = "Reviewer 2"
+    fw2.domains[0].questions[0].response = ReasonedResponseWithEvidenceAndRawData(
+        evidence=[], reasoning="", response="No"
+    )
+
+    df = compare_frameworks(fw1, fw2)
+
+    assert list(df.columns[:2]) == ["domain", "question"]
+    assert "Reviewer 1" in df.columns
+    assert "Reviewer 2" in df.columns
+
+    first_row = df.iloc[0]
+    assert first_row["Reviewer 1"] == "Yes"
+    assert first_row["Reviewer 2"] == "No"
+    assert len(df) == sum(len(d.questions) for d in fw1.domains)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -30,8 +30,6 @@ def test_compare_frameworks() -> None:
 
     df = compare_frameworks(fw1, fw2)
 
-    print(df)
-
     assert list(df.columns[:4]) == [
         "domain_short",
         "question_short",
@@ -65,5 +63,3 @@ def test_compare_frameworks() -> None:
     assert third_row["Reviewer 1"] == "No"
     assert third_row["Reviewer 2"] == "No"
     assert len(df) == sum(len(d.questions) for d in fw1.domains)
-
-test_compare_frameworks()


### PR DESCRIPTION
## Summary
- add pandas dependency
- implement `compare_frameworks` helper
- document comparison API
- mention comparison in tutorial
- expose comparison from package
- test framework comparison
- delete redundant requirements.txt
- modify comparison helper to accept frameworks directly

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684b59aae2bc832a83092bb4a88ee354