### PR TITLE
fix: add agreement column when comparing frameworks

### DIFF
--- a/risk_of_bias/compare.py
+++ b/risk_of_bias/compare.py
@@ -21,13 +21,15 @@ def compare_frameworks(fw1: Framework, fw2: Framework) -> pd.DataFrame:
     pandas.DataFrame
         Long-form table with ``domain_short``, ``question_short``, ``domain``,
         ``question`` and one column per assessor containing their responses.
-        If a question was unanswered, the value will be ``None``.
+        If a question was unanswered, the value will be ``None``. The final
+        column ``agreement`` indicates if the assessors provided the same
+        response.
     """
 
     assessor1 = fw1.assessor or "assessor_1"
     assessor2 = fw2.assessor or "assessor_2"
 
-    rows: list[dict[str, str | None]] = []
+    rows: list[dict[str, str | bool | None]] = []
     if len(fw1.domains) != len(fw2.domains):
         raise ValueError("Frameworks have different numbers of domains")
 
@@ -52,6 +54,7 @@ def compare_frameworks(fw1: Framework, fw2: Framework) -> pd.DataFrame:
                     "question": q1.question,
                     assessor1: a1,
                     assessor2: a2,
+                    "agreement": a1 == a2,
                 }
             )
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -38,12 +38,14 @@ def test_compare_frameworks() -> None:
     ]
     assert "Reviewer 1" in df.columns
     assert "Reviewer 2" in df.columns
+    assert "agreement" in df.columns
 
     first_row = df.iloc[0]
     assert first_row["domain_short"] == "D1"
     assert first_row["question_short"] == "Q1.1"
     assert first_row["Reviewer 1"] == "Yes"
     assert first_row["Reviewer 2"] == "No"
+    assert not first_row["agreement"]
 
     second_row = df[
         (df["domain"] == fw1.domains[0].name)
@@ -53,6 +55,7 @@ def test_compare_frameworks() -> None:
     assert second_row["question_short"] == "Q1.2"
     assert second_row["Reviewer 1"] == "Yes"
     assert second_row["Reviewer 2"] == "Yes"
+    assert second_row["agreement"]
 
     third_row = df[
         (df["domain"] == fw1.domains[1].name)
@@ -62,4 +65,5 @@ def test_compare_frameworks() -> None:
     assert third_row["question_short"] == "Q2.1"
     assert third_row["Reviewer 1"] == "No"
     assert third_row["Reviewer 2"] == "No"
+    assert third_row["agreement"]
     assert len(df) == sum(len(d.questions) for d in fw1.domains)


### PR DESCRIPTION
## Summary
- add `agreement` column to compare result
- test that `agreement` column is calculated correctly

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684bb379c29c832ab20a433506560b92