### PR TITLE
docs: add AI provider configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ You can install the program using the following pip command:
 pip install risk_of_bias[all]
 ```
 
+### AI Provider
+
+An AI provider is required to perform analyses. The package currently supports
+the OpenAI API. Create an account at
+[OpenAI](https://platform.openai.com/) and set the API key as an environment
+variable before running any commands:
+
+```console
+export OPENAI_API_KEY="sk-..."
+```
+
 
 ### Command Line Interface
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,17 @@ You can install the program using the following pip command:
 pip install risk_of_bias[all]
 ```
 
+### AI Provider
+
+Risk of bias analysis relies on a large language model. Currently only the
+OpenAI API is supported. After creating an account on
+[OpenAI](https://platform.openai.com/), export your key before running any
+commands:
+
+```console
+export OPENAI_API_KEY="sk-..."
+```
+
 ### Command Line Interface
 
 The package comes with an easy to use command line interface (CLI) tool.


### PR DESCRIPTION
## Summary
- document how to configure an AI provider via `OPENAI_API_KEY`

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684e35fda038832a99a06eeee53bc4dd