### PR TITLE
Add framework judgement export support

### DIFF
--- a/risk_of_bias/export.py
+++ b/risk_of_bias/export.py
@@ -24,6 +24,9 @@ def export_framework_as_markdown(framework: Framework, path: Path) -> None:
     if framework.manuscript:
         lines.append(f"\n**Manuscript:** {framework.manuscript}")
 
+    if framework.judgement:
+        lines.append(f"\n**Overall Judgement:** {framework.judgement}")
+
     for domain in framework.domains:
         lines.append(f"\n## Domain {domain.index}: {domain.name}")
         if domain.judgement:
@@ -70,6 +73,9 @@ def export_framework_as_html(framework: Framework, path: Path) -> None:
     # Add manuscript name if available
     if framework.manuscript:
         children.append(p[strong["Manuscript: "], framework.manuscript])
+
+    if framework.judgement:
+        children.append(p[strong["Overall Judgement: "], framework.judgement])
 
     for domain in framework.domains:
         children.append(h2[f"Domain {domain.index}: {domain.name}"])

--- a/risk_of_bias/summary.py
+++ b/risk_of_bias/summary.py
@@ -72,7 +72,10 @@ def summarise_frameworks(
 
     The function reads the :pyattr:`~risk_of_bias.types._domain_types.Domain.judgement`
     property of each domain. This property dynamically computes the risk judgement
-    based on the domain's current question responses.
+    based on the domain's current question responses. If a framework does not
+    include a domain explicitly named ``"Overall"``, the returned summary will
+    include an ``"Overall"`` entry computed from the
+    :pyattr:`~risk_of_bias.types._framework_types.Framework.judgement` property.
 
     Key applications include:
     - Creating summary tables for systematic review publications
@@ -108,6 +111,10 @@ def summarise_frameworks(
         domain_results: dict[str, str | None] = {}
         for domain in fw.domains:
             domain_results[domain.name] = domain.judgement
+
+        if "Overall" not in domain_results:
+            domain_results["Overall"] = fw.judgement
+
         summary[manuscript] = domain_results
     return summary
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -187,3 +187,27 @@ def test_end_to_end_framework_with_manuscript_exports(tmp_path: Path) -> None:
 
     assert "**Manuscript:** end_to_end_test.pdf" in md_content
     assert "<strong>Manuscript: </strong>end_to_end_test.pdf" in html_content
+
+
+def test_markdown_export_includes_framework_judgement(tmp_path: Path) -> None:
+    domain1 = Domain(index=1, name="D1", judgement_function=lambda d: "Low")
+    domain2 = Domain(index=2, name="D2", judgement_function=lambda d: "High")
+    framework = Framework(name="Test", domains=[domain1, domain2])
+
+    export_path = tmp_path / "fw.md"
+    export_framework_as_markdown(framework, export_path)
+
+    content = export_path.read_text()
+    assert "**Overall Judgement:** High" in content
+
+
+def test_html_export_includes_framework_judgement(tmp_path: Path) -> None:
+    domain1 = Domain(index=1, name="D1", judgement_function=lambda d: "Low")
+    domain2 = Domain(index=2, name="D2", judgement_function=lambda d: "High")
+    framework = Framework(name="Test", domains=[domain1, domain2])
+
+    export_path = tmp_path / "fw.html"
+    export_framework_as_html(framework, export_path)
+
+    content = export_path.read_text()
+    assert "<strong>Overall Judgement: </strong>High" in content

--- a/tests/test_framework_io.py
+++ b/tests/test_framework_io.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from risk_of_bias.frameworks.rob2 import get_rob2_framework
+from risk_of_bias.types._domain_types import Domain
 from risk_of_bias.types._framework_types import Framework
 
 
@@ -53,3 +54,22 @@ def test_framework_str_includes_manuscript() -> None:
     framework.manuscript = "test_study.pdf"
     str_repr = str(framework)
     assert "Manuscript: test_study.pdf" in str_repr
+
+
+def test_framework_judgement_property() -> None:
+    domain1 = Domain(index=1, name="Random", judgement_function=lambda d: "Low")
+    domain2 = Domain(index=2, name="Deviation", judgement_function=lambda d: "High")
+    framework = Framework(name="T", domains=[domain1, domain2])
+
+    assert framework.judgement == "High"
+
+    domain2.judgement_function = None
+    assert framework.judgement is None
+
+    domain_overall = Domain(
+        index=3, name="Overall", judgement_function=lambda d: "High"
+    )
+    framework.domains.append(domain_overall)
+    domain1.judgement_function = lambda d: "Low"
+    domain2.judgement_function = lambda d: "Low"
+    assert framework.judgement == "Low"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -9,6 +9,8 @@ from risk_of_bias.summary import (
     print_summary,
     summarise_frameworks,
 )
+from risk_of_bias.types._domain_types import Domain
+from risk_of_bias.types._framework_types import Framework
 from risk_of_bias.types._response_types import ReasonedResponseWithEvidenceAndRawData
 
 
@@ -78,6 +80,23 @@ def test_export_summary_uses_overall_domain(tmp_path: Path) -> None:
             domain.judgement_function = lambda _d: "High"
         else:
             domain.judgement_function = lambda _d: "Low"
+
+    summary = summarise_frameworks([framework])
+    export_path = tmp_path / "summary.csv"
+    export_summary(summary, export_path)
+
+    rows = [line.split(",") for line in export_path.read_text().splitlines()]
+    header = rows[0]
+    data = rows[1]
+    assert header[-1] == "Overall"
+    assert data[-1] == "High"
+
+
+def test_export_summary_uses_framework_judgement(tmp_path: Path) -> None:
+    domain1 = Domain(index=1, name="D1", judgement_function=lambda d: "Low")
+    domain2 = Domain(index=2, name="D2", judgement_function=lambda d: "High")
+    framework = Framework(name="T", domains=[domain1, domain2])
+    framework.manuscript = "studyC.pdf"
 
     summary = summarise_frameworks([framework])
     export_path = tmp_path / "summary.csv"


### PR DESCRIPTION
## Summary
- include `Framework.judgement` in markdown and HTML exports
- compute an `Overall` column when missing using `Framework.judgement`
- document this behaviour in `summarise_frameworks`
- add regression tests for new export behaviour

## Testing
- `pytest -v --tb=short`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68747eb3ab6c832a832e8570b79467c6